### PR TITLE
Fix typo in views.py

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -15,7 +15,7 @@ def login_view(request):
     
     if username is None or password is None:
         return JsonResponse({"detail":"Please provide username and password"})
-    user = authenticate(username=username, passowrd=password)
+    user = authenticate(username=username, password=password)
     if user is None:
         return JsonResponse({"detail":"invalid credentials"}, status=400)
     login(request, user)


### PR DESCRIPTION
Fix the typo of the argument name sent to authenticate function in login_view

Without this, the login page will not work and will always return invalid credential to frontend